### PR TITLE
Release/patch release v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.8] - 2021-01-05
 ### Changed
- - Bump `pipenv` CLI version to v20.11.4.
+ - Bump `pipenv` CLI version to v2020.11.15.
  - Bump `poetry` CLI version to v1.1.4.
 
 ## [0.1.9] - 2021-01-06
 ### Changed
  - Bump Python version to v3.8.6.
+
+## [0.1.10] - 2021-01-08
+### Changed
+ - Downgrade `pipenv` CLI version to v2020.11.4.

--- a/fixtures/python/Pipfile
+++ b/fixtures/python/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [requires]
-python_version = "3.8"
+python_full_version = "3.8.6"
 
 [pipenv]
 allow_prereleases = true

--- a/fixtures/python/Pipfile.lock
+++ b/fixtures/python/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1e8f94f906111f13333e6a1aff615deb8446ecf148b24a632a50b202160ce71f"
+            "sha256": "6c5b597dee31855ee40ebe87774e8b7eb6bb38822f52f712e8d3abb48b1f2c65"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.8"
+            "python_full_version": "3.8.6"
         },
         "sources": [
             {

--- a/src/commands/python-install-cli.yml
+++ b/src/commands/python-install-cli.yml
@@ -5,5 +5,5 @@ steps:
       name: Install pipenv/poetry packages.
       command: pip install pipenv==$PIPENV_RELEASE poetry==$POETRY_RELEASE
       environment:
-        PIPENV_RELEASE: 2020.11.15
+        PIPENV_RELEASE: 2020.11.4
         POETRY_RELEASE: 1.1.4


### PR DESCRIPTION
candidate release v0.1.10

Downgrade `pipenv` version to v2020.11.4 ; currently, opened issues for installing dependencies defined in `setup.py` from the root package as editable.

https://github.com/pypa/pipenv/issues/4542