### PR TITLE
NOOS-876/hotfix-venv-caching

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -21,7 +21,7 @@ release-filters: &release-filters
 # ----------------
 
 orbs:
-  orb-tools: circleci/orb-tools@12.0.4
+  orb-tools: circleci/orb-tools@12.1.0
   noos-ci: noosenergy/noos-ci@dev:<<pipeline.git.revision>>
 
 # --------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - Add circleci no_output_timeout parameter for docker build image.
 
-## [0.2.5] - 2024-08-21
+## [0.3.0] - 2024-08-21
 ### Added
  - Add `uv` python package manager.`
+
+## [0.3.1] - 2024-08-23
+### Changed
+ - Remove `uv` CI caching strategy (ensure pre-built wheels are cached).
+ - Ensure CircleCI Python caching keys are coherent between root / branch and lock hash.
+ - Add Python executor with a Timesacle side-car container.

--- a/src/commands/python_configure_venv.yml
+++ b/src/commands/python_configure_venv.yml
@@ -78,7 +78,6 @@ steps:
             name: Install Python packages
             command: |
               uv sync --frozen << parameters.install_args >>
-              uv cache prune --ci
         - save_cache:
             key: "virtualenv-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-\
               {{ checksum \"uv.lock\" }}"

--- a/src/commands/python_configure_venv.yml
+++ b/src/commands/python_configure_venv.yml
@@ -1,6 +1,6 @@
 ---
 
-description: Spinup Python virtual environment [pipenv or poetry].
+description: Spinup Python virtual environment [pipenv, poetry or uv].
 
 parameters:
   pkg_manager:
@@ -32,8 +32,8 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - virtualenv-{{ .Environment.CACHE_VERSION }}
-                -{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+              - "virtualenv-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-\
+                {{ checksum \"Pipfile.lock\" }}"
               - virtualenv-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
               - virtualenv-{{ .Environment.CACHE_VERSION }}-
         - run:
@@ -42,8 +42,8 @@ steps:
               pipenv sync << parameters.install_args >>
               pipenv clean
         - save_cache:
-            key: virtualenv-{{ .Environment.CACHE_VERSION }}
-              -{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+            key: "virtualenv-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-\
+              {{ checksum \"Pipfile.lock\" }}"
             paths:
               - "./.venv"
   - when:
@@ -52,16 +52,16 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - virtualenv-{{ .Environment.CACHE_VERSION }}
-                -{{ .Branch }}-{{ checksum "poetry.lock" }}
+              - "virtualenv-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-\
+                {{ checksum \"poetry.lock\" }}"
               - virtualenv-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
               - virtualenv-{{ .Environment.CACHE_VERSION }}-
         - run:
             name: Install Python packages
             command: poetry install << parameters.install_args >>
         - save_cache:
-            key: virtualenv-{{ .Environment.CACHE_VERSION }}
-              -{{ .Branch }}-{{ checksum "poetry.lock" }}
+            key: "virtualenv-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-\
+              {{ checksum \"poetry.lock\" }}"
             paths:
               - "./.venv"
   - when:
@@ -70,8 +70,8 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - virtualenv-{{ .Environment.CACHE_VERSION }}
-                -{{ .Branch }}-{{ checksum "uv.lock" }}
+              - "virtualenv-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-\
+                {{ checksum \"uv.lock\" }}"
               - virtualenv-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
               - virtualenv-{{ .Environment.CACHE_VERSION }}-
         - run:
@@ -80,7 +80,7 @@ steps:
               uv sync --frozen << parameters.install_args >>
               uv cache prune --ci
         - save_cache:
-            key: virtualenv-{{ .Environment.CACHE_VERSION }}
-              -{{ .Branch }}-{{ checksum "uv.lock" }}
+            key: "virtualenv-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-\
+              {{ checksum \"uv.lock\" }}"
             paths:
               - $UV_CACHE_DIR

--- a/src/commands/python_configure_venv.yml
+++ b/src/commands/python_configure_venv.yml
@@ -82,4 +82,4 @@ steps:
             key: "virtualenv-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-\
               {{ checksum \"uv.lock\" }}"
             paths:
-              - $UV_CACHE_DIR
+              - "./.uv-cache"

--- a/src/executors/timescale.yml
+++ b/src/executors/timescale.yml
@@ -1,0 +1,30 @@
+---
+
+# https://hub.docker.com/r/noosenergy/circleci
+# https://github.com/noosenergy/noos-docker-images/tree/master/docker/circleci
+# https://circleci.com/developer/images/image/cimg/postgres
+
+description: Preconfigured CircleCI Python image with Timescale side-car.
+
+parameters:
+  tag:
+    type: string
+    default: latest
+  db_tag:
+    type: string
+    default: "latest-pg16"
+  db_user:
+    type: string
+    default: postgres
+  db_password:
+    type: string
+    default: postgres
+
+docker:
+  - image: noosenergy/circleci:<< parameters.tag >>
+  - image: timescale/timescaledb:<< parameters.db_tag >>
+    environment:
+      POSTGRES_USER: << parameters.db_user >>
+      POSTGRES_PASSWORD: << parameters.db_password >>
+
+working_directory: "~/project"


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [x] Patch

## Description:

- Expected: CI cache size with `pipenv` (21 MB)
https://app.circleci.com/pipelines/github/noosenergy/noos-circleci-orb/458/workflows/46d164da-bd71-4439-8034-3ca01ee1bef9/jobs/2607

- Currently: CI cache size with `uv` (32 B , almost null)
https://app.circleci.com/pipelines/github/noosenergy/noos-circleci-orb/458/workflows/46d164da-bd71-4439-8034-3ca01ee1bef9/jobs/2611
