### PR TITLE
NOOS-1642/add-uv-lock-check-when-setting-up-venv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,3 +177,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  ## [0.4.6] - 2026-01-07
 ### Changed
  - Check lockfile matches the project metadata before setup python venv
+ - Bump Slack CireclCI Orb to v6.1.2
+ - Bump Helm binary to v3.18.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,3 +173,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Bump AWS CircleCI Orb to v5.4.1.
  - Bump Helm CircleCI Orb to v3.2.0.
  - Bump Slack CircleCI Orb to v6.0.0.
+
+ ## [0.4.6] - 2026-01-07
+### Changed
+ - Check lockfile matches the project metadata before setup python venv

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,5 +1,4 @@
 ---
-
 version: 2.1
 
 description: Noos Energy CircleCI Orb for CI/CD pipelines
@@ -11,4 +10,4 @@ display:
 orbs:
   aws-cli: circleci/aws-cli@5.4.1
   helm-cli: circleci/helm@3.2.0
-  slack-msg: circleci/slack@6.0.0
+  slack-msg: circleci/slack@6.1.2

--- a/src/commands/helm_install_cli.yml
+++ b/src/commands/helm_install_cli.yml
@@ -1,7 +1,6 @@
 ---
-
 description: Install Helm local client.
 
 steps:
   - helm-cli/install_helm_client:
-      version: v3.16.1
+      version: v3.18.6

--- a/src/commands/python_configure_venv.yml
+++ b/src/commands/python_configure_venv.yml
@@ -1,5 +1,4 @@
 ---
-
 description: Spinup Python virtual environment [pipenv, poetry or uv].
 
 parameters:
@@ -77,6 +76,7 @@ steps:
         - run:
             name: Install Python packages
             command: |
+              uv lock --check
               uv sync --frozen << parameters.install_args >>
         - save_cache:
             key: "virtualenv-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-\


### PR DESCRIPTION
# Description
Check lockfile matches the project metadata when setting up python venv
<!--- Add JIRA reference here -->
**JIRA Reference**: [NOOS-1642](https://noosenergy.atlassian.net/browse/NOOS-1642)

## Deployment

Once merged, check deployment on [circleci](https://app.circleci.com/pipelines/github/noosenergy/noos-circleci-orb)


[NOOS-1642]: https://noosenergy.atlassian.net/browse/NOOS-1642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ